### PR TITLE
fix(source): Simplygo unable to scrape unposted trips

### DIFF
--- a/pipelines/ingest/simplygo.py
+++ b/pipelines/ingest/simplygo.py
@@ -59,7 +59,7 @@ def ingest_simplygo_dag(
         },
         arguments=[
             "--trips-from",
-            "{{  ds }}",
+            "{{ ds }}",
             "--trips-to",
             "{{ ds }}",
             "--output",

--- a/sources/simplygo/resources/simplygo_card_gettransactions_unposted.html
+++ b/sources/simplygo/resources/simplygo_card_gettransactions_unposted.html
@@ -1,0 +1,99 @@
+<fieldset>
+  <legend>TRAVEL / PAYMENT HISTORY</legend>
+  <div class="form-record">
+    <table>
+      <tr>
+        <td>
+          <table class="Table-payment-statement table table-condensed" style="border-collapse:collapse;">
+            <thead class="Table-payment-statement">
+              <tr>
+                <th>&nbsp;</th>
+                <th class="col1">Date/Time</th>
+                <th class="col2">Transactions</th>
+                <th class="col3">Amount</th>
+                <th class="col4">Status</th>
+                <th>&nbsp;</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="journey_p_collapse" data-prow="01">
+                <td class="col6">
+                  <i class="icon-p-01 fa fa-plus-circle" style="font-size: 1.5em; margin-top: -1px;"
+                    aria-hidden="true"></i>
+                </td>
+                <td class="col1">Thu, 13-Apr-2023</td>
+                <td class="col2">
+                  Outram Park NEL - Bukit Gombak
+                  <div style="font-size:13px;">
+
+                  </div>
+                </td>
+                <td class="col3">$1.85 </td>
+                <td class="col4">
+                  <img src="https://simplygo.transitlink.com.sg/Content/images/common/icon-dots.png" alt="" />
+                </td>
+                <td class="col5">
+                  <img src="https://simplygo.transitlink.com.sg/Content/images/common/icon-virtual-device.gif ">
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="summary data-p-row-item-01" style="display:none">
+            <table class="Table-payment-statement-mobile table table-condensed" style="border-collapse:collapse;">
+              <thead class="Table-payment-statement-mobile">
+                <tr>
+                  <th class="hiddenRow data-01">
+                    <div class="row_items data-func-01" style="height:0px;padding:0px">&nbsp;</div>
+                  </th>
+                  <th class="hiddenRow data-01">
+                    <div class="row_items data-func-01">Date/Time</div>
+                  </th>
+                  <th class="hiddenRow data-01">
+                    <div class="row_items data-func-01">Journey</div>
+                  </th>
+                  <th class="hiddenRow data-01">
+                    <div class="row_items data-func-01">Charges</div>
+                  </th>
+                  <th class="hiddenRow data-01">
+                    <div class="row_items data-func-01">Status</div>
+                  </th>
+                  <th class="hiddenRow data-01">
+                    <div class="row_items data-func-01">&nbsp;</div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="hiddenRow data-01 col6" style="height:0px;padding:0px">
+                    <div class="row_items data-func-01">&nbsp;</div>
+                  </td>
+                  <td class="hiddenRow data-01 col1">
+                    <div class="row_items data-func-01">09:04 AM</div>
+                  </td>
+                  <td class="hiddenRow data-01 col2">
+                    <div class="row_items data-func-01">
+                      Outram Park NEL - Bukit Gombak
+                    </div>
+                  </td>
+                  <td class="hiddenRow data-01 col3">
+                    <div class="row_items data-func-01">$1.85</div>
+                  </td>
+                  <td class="hiddenRow data-01 col4">
+                    <div class="row_items data-func-01">
+                      <img src="https://simplygo.transitlink.com.sg/Content/images/common/icon-dots.png" alt="" />
+                    </div>
+                  </td>
+                  <td class="hiddenRow data-01 col5">
+                    <div class="row_items data-func-01">
+                      <img src="https://simplygo.transitlink.com.sg/Content/images/common/icon-rail.gif" alt="">
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </div>
+</fieldset>

--- a/sources/simplygo/src/simplygo/models.rs
+++ b/sources/simplygo/src/simplygo/models.rs
@@ -31,7 +31,7 @@ pub struct Leg {
 #[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct Trip {
     /// Reference no. if the the trip was "Posted" ie. charged on the bank account.
-    /// If the trip has not be posted this field will be null
+    /// If the trip has not be posted this field will be None.
     pub posting_ref: Option<String>,
     /// Date on which this trip was made in the Asia/Singapore time zone.
     pub traveled_on: NaiveDate,

--- a/sources/simplygo/src/simplygo/parsing.rs
+++ b/sources/simplygo/src/simplygo/parsing.rs
@@ -46,7 +46,7 @@ fn parse_date(date_str: &str) -> NaiveDate {
 /// Parse Posting Ref in format: '[Posting Ref No : <POSTING_REF>]'
 fn parse_posting(posting_str: &str) -> Option<&str> {
     let trim_posting = posting_str.trim();
-    if trim_posting.len() <= 0 {
+    if trim_posting.len() == 0 {
         None
     } else {
         Some(

--- a/sources/simplygo/src/simplygo/parsing.rs
+++ b/sources/simplygo/src/simplygo/parsing.rs
@@ -44,15 +44,22 @@ fn parse_date(date_str: &str) -> NaiveDate {
 }
 
 /// Parse Posting Ref in format: '[Posting Ref No : <POSTING_REF>]'
-fn parse_posting(posting_str: &str) -> &str {
-    posting_str
-        .split_once(':')
-        .expect("Malformed Posting Ref.")
-        .1
-        .split_once(']')
-        .expect("Malformed Posting Ref.")
-        .0
-        .trim()
+fn parse_posting(posting_str: &str) -> Option<&str> {
+    let trim_posting = posting_str.trim();
+    if trim_posting.len() <= 0 {
+        None
+    } else {
+        Some(
+            posting_str
+                .split_once(':')
+                .expect("Malformed Posting Ref.")
+                .1
+                .split_once(']')
+                .expect("Malformed Posting Ref.")
+                .0
+                .trim(),
+        )
+    }
 }
 
 /// Parse source and destination from journey column in the <tr> tag representing
@@ -133,16 +140,21 @@ fn parse_trip_legs(tr: &ElementRef) -> Vec<Leg> {
 /// Parse Trips from the given /Card/GetTransactions html
 pub fn parse_trips(html: &str) -> Vec<Trip> {
     // css selectors for parsing trip
-    // extra ,<tbody> automatically inserted on html parsing
+    // extra <tbody> automatically inserted on html parsing
     let trip_record_sel = Selector::parse(".form-record > table > tbody > tr").unwrap();
     let statement_sel = Selector::parse(".journey_p_collapse").unwrap();
     let date_sel = Selector::parse("td.col1").unwrap();
+    let posting_table_sel = Selector::parse(".Table-payment-statement-post").unwrap();
     let posting_sel = Selector::parse("td.col2 > div").unwrap();
     let document = Html::parse_document(html);
     document
         .select(&trip_record_sel)
-        // skip payment posting statement row
-        .skip(1)
+        // skip payment posting statement table if it exists
+        .skip(if document.select(&posting_table_sel).count() > 0 {
+            1
+        } else {
+            0
+        })
         .map(|tr| {
             // parse trip from payment statement
             let statement = tr
@@ -157,10 +169,14 @@ pub fn parse_trips(html: &str) -> Vec<Trip> {
                         .expect("Missing expected 'Date/Time' column in Payment Statement.")
                         .inner_html(),
                 ),
-                posting_ref: statement
-                    .select(&posting_sel)
-                    .next()
-                    .map(|div| parse_posting(&div.inner_html()).to_owned()),
+                posting_ref: parse_posting(
+                    &statement
+                        .select(&posting_sel)
+                        .next()
+                        .expect("Missing expected Posting Ref <div> in Payment Statement.")
+                        .inner_html(),
+                )
+                .map(|s| s.to_owned()),
                 legs: parse_trip_legs(&tr),
             }
         })

--- a/sources/simplygo/src/simplygo/parsing/tests.rs
+++ b/sources/simplygo/src/simplygo/parsing/tests.rs
@@ -138,6 +138,8 @@ fn parse_trips_test() {
     let html = load_html("simplygo_card_gettransactions.html");
     let trip_trs: Vec<_> = html
         .select(&Selector::parse(TRIP_CSS_SELECTOR).unwrap())
+        // skip first <tr>: trip posting record
+        .skip(1)
         .collect();
     let trips = parse_trips(&html.html());
     assert!(trips.len() > 0);

--- a/sources/simplygo/src/simplygo/parsing/tests.rs
+++ b/sources/simplygo/src/simplygo/parsing/tests.rs
@@ -165,13 +165,11 @@ fn parse_trips_unposted() {
         .select(&Selector::parse(TRIP_CSS_SELECTOR).unwrap())
         .collect();
     let trips = parse_trips(&html.html());
-    assert!(vec![
-        Trip {
-            posting_ref: None,
-            traveled_on: NaiveDate::from_ymd_opt(2023, 4, 13).unwrap(),
-            legs: parse_trip_legs(&trip_trs[0]),
-        },
-    ]
+    assert!(vec![Trip {
+        posting_ref: None,
+        traveled_on: NaiveDate::from_ymd_opt(2023, 4, 13).unwrap(),
+        legs: parse_trip_legs(&trip_trs[0]),
+    },]
     .into_iter()
     .zip(trips)
     .all(|(expected, actual)| expected == actual))

--- a/sources/simplygo/src/simplygo/parsing/tests.rs
+++ b/sources/simplygo/src/simplygo/parsing/tests.rs
@@ -10,8 +10,7 @@ use chrono::NaiveDate;
 
 use super::*;
 
-// skip first <tr>: trip posting record
-const TRIP_CSS_SELECTOR: &str = ".form-record > table > tbody > tr:not(:first-child)";
+const TRIP_CSS_SELECTOR: &str = ".form-record > table > tbody > tr";
 const LEG_CSS_SELECTOR: &str = ".data-p-row-item-01 tbody > tr";
 
 // Load HTML page from resources for testing
@@ -62,8 +61,9 @@ fn parse_posting_test() {
     let posting_ref = "_POSTING_REF";
     assert_eq!(
         parse_posting(&format!("[Posting Ref No : {}]", posting_ref)),
-        posting_ref
+        Some(posting_ref)
     );
+    assert_eq!(parse_posting("                     "), None);
 }
 
 #[test]
@@ -105,6 +105,8 @@ fn parse_trip_legs_test() {
         // extra <tbody> automatically inserted on html parsing
         &html
             .select(&Selector::parse(TRIP_CSS_SELECTOR).unwrap())
+            // skip first <tr>: trip posting record
+            .skip(1)
             .next()
             .unwrap(),
     );
@@ -150,6 +152,25 @@ fn parse_trips_test() {
             traveled_on: NaiveDate::from_ymd_opt(2023, 2, 22).unwrap(),
             legs: parse_trip_legs(&trip_trs[1]),
         }
+    ]
+    .into_iter()
+    .zip(trips)
+    .all(|(expected, actual)| expected == actual))
+}
+
+#[test]
+fn parse_trips_unposted() {
+    let html = load_html("simplygo_card_gettransactions_unposted.html");
+    let trip_trs: Vec<_> = html
+        .select(&Selector::parse(TRIP_CSS_SELECTOR).unwrap())
+        .collect();
+    let trips = parse_trips(&html.html());
+    assert!(vec![
+        Trip {
+            posting_ref: None,
+            traveled_on: NaiveDate::from_ymd_opt(2023, 4, 13).unwrap(),
+            legs: parse_trip_legs(&trip_trs[0]),
+        },
     ]
     .into_iter()
     .zip(trips)


### PR DESCRIPTION
# Motivation
Simplygo Source unable to scrape unposted trips
- it leaves trips empty, even though an unposted trip is record in Simplygo

# Contents
Fix Simplygo source unable to scrape unposted trips:
- don't always skip posting table as it does not exist for unposted trips,
    &amp; skips trip data.
